### PR TITLE
changes for AFP

### DIFF
--- a/GallopA.thy
+++ b/GallopA.thy
@@ -1,5 +1,5 @@
 theory GallopA
-  imports "Simpl/Vcg" Main "~~/src/HOL/Library/Code_Target_Numeral" "TimSortLemma" "TimSortProc"
+  imports "TimSortProc"
 begin
 
 
@@ -396,9 +396,16 @@ CATCH
 Skip
 END"
         in HoarePartial.annotateI) 
-   apply vcg 
-    apply (simp_all)
-    apply (auto simp add:Suc_diff_Suc)
+  apply vcg
+  subgoal by (simp add:Suc_diff_Suc)
+  subgoal by simp
+  subgoal
+    apply simp
+    using less_imp_diff_less by force
+  subgoal by simp
+  subgoal by (auto simp add:Suc_diff_Suc)
+  subgoal by simp
+  subgoal by simp
   done 
 
 

--- a/ROOT
+++ b/ROOT
@@ -1,4 +1,5 @@
 session "TimSort" = Simpl +
+  options [timeout = 1800]
   theories
     TimSortLemma
     TimSortProc

--- a/ROOT
+++ b/ROOT
@@ -1,7 +1,8 @@
 session "TimSort" = Simpl +
-  options [document = false]
   theories
     TimSortLemma
     TimSortProc
     GallopA
     TimSort
+  document_files
+    "root.tex"

--- a/ROOT
+++ b/ROOT
@@ -1,8 +1,5 @@
-session "TimSort" = "HOL" +
+session "TimSort" = Simpl +
   options [document = false]
-  sessions
-    "HOL-Library"
-    "HOL-Statespace"
   theories
     TimSortLemma
     TimSortProc

--- a/TimSort.thy
+++ b/TimSort.thy
@@ -1,5 +1,5 @@
 theory TimSort
-  imports "Simpl/Vcg" Main "~~/src/HOL/Library/Code_Target_Numeral" "TimSortLemma" "TimSortProc" "GallopA"
+  imports "GallopA"
 begin
 
 definition equal_size :: "nat list \<Rightarrow> nat list \<Rightarrow> bool" where

--- a/TimSortLemma.thy
+++ b/TimSortLemma.thy
@@ -1,5 +1,5 @@
 theory TimSortLemma
-  imports  Main "~~/src/HOL/Library/Code_Target_Numeral" 
+  imports  Main "HOL-Library.Code_Target_Numeral" 
 begin
 definition list_copy :: "'a list \<Rightarrow> nat \<Rightarrow> 'a list  \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> 'a list" where
 "list_copy xs n ys m l = (take n xs) @ (take l (drop m ys)) @ (drop (n+l) xs)"

--- a/TimSortProc.thy
+++ b/TimSortProc.thy
@@ -1,5 +1,5 @@
 theory TimSortProc
-  imports "Simpl/Vcg" Main "~~/src/HOL/Library/Code_Target_Numeral" "TimSortLemma"
+  imports "Simpl.Vcg" "TimSortLemma"
 begin 
 
 hoarestate globals_var = 

--- a/document/root.tex
+++ b/document/root.tex
@@ -1,0 +1,59 @@
+\documentclass[11pt,a4paper]{article}
+\usepackage{isabelle,isabellesym}
+
+% further packages required for unusual symbols (see also
+% isabellesym.sty), use only when needed
+
+%\usepackage{amssymb}
+  %for \<leadsto>, \<box>, \<diamond>, \<sqsupset>, \<mho>, \<Join>,
+  %\<lhd>, \<lesssim>, \<greatersim>, \<lessapprox>, \<greaterapprox>,
+  %\<triangleq>, \<yen>, \<lozenge>
+
+%\usepackage{eurosym}
+  %for \<euro>
+
+%\usepackage[only,bigsqcap]{stmaryrd}
+  %for \<Sqinter>
+
+%\usepackage{eufrak}
+  %for \<AA> ... \<ZZ>, \<aa> ... \<zz> (also included in amssymb)
+
+%\usepackage{textcomp}
+  %for \<onequarter>, \<onehalf>, \<threequarters>, \<degree>, \<cent>,
+  %\<currency>
+
+% this should be the last package used
+\usepackage{pdfsetup}
+
+% urls in roman style, theory text in math-similar italics
+\urlstyle{rm}
+\isabellestyle{it}
+
+% for uniform font size
+%\renewcommand{\isastyle}{\isastyleminor}
+
+
+\begin{document}
+
+\title{Verified C implementation of TimSort}
+\author{Yu Zhang and Yongwang Zhao}
+\maketitle
+
+\tableofcontents
+
+% sane default for proof documents
+\parindent 0pt\parskip 0.5ex
+
+% generated text of all theories
+\input{session}
+
+% optional bibliography
+%\bibliographystyle{abbrv}
+%\bibliography{root}
+
+\end{document}
+
+%%% Local Variables:
+%%% mode: latex
+%%% TeX-master: t
+%%% End:


### PR DESCRIPTION
Can be built as follows:

$ isabelle build -bv -d '/path/to/afp-2018' -D . -o document=pdf

The imports now refer to the official version of `Simpl` in the AFP, not the local copy that is in this repository.
